### PR TITLE
add rbenv to path before initializing

### DIFF
--- a/bashrc
+++ b/bashrc
@@ -30,7 +30,8 @@ export EDITOR="vim"
 # update bash history after each command
 export PROMPT_COMMAND="history -a"
 
-# Recommended by rbenv
+# initialize rbenv
+export PATH="$PATH:$HOME/.rbenv/bin"
 eval "$(rbenv init -)"
 
 export PATH="$PATH:$HOME/.bin"


### PR DESCRIPTION
Students keep running into issues where "pry" isn't a command, or they have to "sudo" to install a gem. This should fix that.