### PR TITLE
Don't set vim as default editor

### DIFF
--- a/dot/bashrc
+++ b/dot/bashrc
@@ -11,9 +11,6 @@ export PATH="$HOME/.rbenv/bin:$PATH"
 export PATH="/usr/local/heroku/bin:$PATH"
 export PATH="$HOME/.bin:$PATH"
 
-# make vim the default text editor
-export EDITOR="vim"
-
 # shortened prompt that includes git branch info
 RED='\[\e[0;31m\]'
 WHITE='\[\e[1;37m\]'


### PR DESCRIPTION
The vim package is no longer installed as of e4858c3, so it doesn't make sense to set it as the default editor (unless we really just want to use the system vim).
